### PR TITLE
Basin Tickers hotfix

### DIFF
--- a/src/service/coingecko-service.js
+++ b/src/service/coingecko-service.js
@@ -1,6 +1,5 @@
 const { BigNumber } = require('alchemy-sdk');
 const SubgraphClients = require('../datasources/subgraph-client');
-const { getConstantProductPrice } = require('../utils/pool/constant-product');
 const BlockUtil = require('../utils/block');
 const { calcPoolLiquidityUSD } = require('../utils/pool/liquidity');
 const { createNumberSpread } = require('../utils/number');
@@ -25,7 +24,7 @@ class CoingeckoService {
       const token0 = well.tokens[0].id;
       const token1 = well.tokens[1].id;
 
-      const poolPrice = getConstantProductPrice(
+      const poolPrice = ConstantProductUtil.getConstantProductPrice(
         well.reserves,
         well.tokens.map((t) => t.decimals)
       );
@@ -76,7 +75,7 @@ class CoingeckoService {
       const type = swap.fromToken.id === tokens[0] ? 'sell' : 'buy';
       retval[type].push({
         trade_id: swap.blockNumber * 10000 + swap.logIndex,
-        price: getConstantProductPrice(
+        price: ConstantProductUtil.getConstantProductPrice(
           [swap.amountIn, swap.amountOut],
           [swap.fromToken.decimals, swap.toToken.decimals]
         ).float[0],

--- a/src/service/price-service.js
+++ b/src/service/price-service.js
@@ -53,7 +53,11 @@ class PriceService {
     } else if (token === WETH) {
       return PriceService.getEthPrice;
     }
-    throw new Error('Price not implemented for the requested token.');
+    return () => ({
+      token: token,
+      usdPrice: 0
+    });
+    // throw new Error('Price not implemented for the requested token.');
   }
 }
 

--- a/src/utils/pool/constant-product.js
+++ b/src/utils/pool/constant-product.js
@@ -1,11 +1,15 @@
 const { BigNumber } = require('alchemy-sdk');
 const NumberUtil = require('../number');
-const { TEN_BN } = require('../../constants/constants');
+const { TEN_BN, ZERO_BN } = require('../../constants/constants');
 
 class ConstantProductUtil {
   // Given the reserves, returns the current price of each token in a constant product pool
   // The prices returned are in terms of the other token
   static getConstantProductPrice(reserves, decimals) {
+    if (ZERO_BN.eq(reserves[0]) || ZERO_BN.eq(reserves[1])) {
+      return NumberUtil.createNumberSpread([ZERO_BN, ZERO_BN], [decimals[1], decimals[0]]);
+    }
+
     const precision = decimals.map((d) => TEN_BN.pow(d));
 
     const token0Price = reserves[1].mul(precision[0]).div(reserves[0]);


### PR DESCRIPTION
- Fix division by zero error for Wells having no reserves.
- Returns 0 price for unknown tokens. Ideally the token price can be derived from CoinGecko, but for now will return 0.