### PR TITLE
[codex] Optimize API RPC usage

### DIFF
--- a/docs/rpc-cost-optimization-port-plan.md
+++ b/docs/rpc-cost-optimization-port-plan.md
@@ -1,0 +1,58 @@
+# RPC Cost Optimization Port Plan
+
+Date: 2026-05-09
+
+This captures the initial Pinto-to-Beanstalk port plan before code changes. It is intentionally redacted: exposed key material is described by source and protection behavior, not copied.
+
+## Pinto Reference Changes
+
+- Pinto frontend:
+  - `Reduce conservative RPC waste`
+  - `Add app version refresh guard`
+- Pinto API:
+  - `Optimize RPC usage`
+- Pinto bots:
+  - `Optimize event RPC polling`
+  - `Add shared event dispatcher`
+  - `Fix dispatcher routing regressions`
+  - `Add Phase 3A RPC cleanup`
+
+## Live Key Exposure Audit
+
+- `https://pinto.money/` currently did not expose full Alchemy RPC URLs in the initial deployed JS/CSS bundle. The source still builds RPC URLs from `VITE_ALCHEMY_API_KEY`, so any configured Vite key is public by design.
+- `https://bean.money/` and `https://www.bean.money/` did not expose Alchemy RPC URLs in the initial deployed JS/CSS bundles checked.
+- `https://app.bean.money/` exposes Alchemy RPC URLs in the deployed app bundle. The Beanstalk production ETH/Arbitrum key matched the local UI production key and rejected requests with no Origin or a foreign Origin, while accepting the app Origin.
+- The Beanstalk app bundle also contains provider-library default/community Alchemy endpoints. One Optimism endpoint accepted a foreign Origin, but it did not match the Beanstalk UI production key.
+- Local Beanstalk UI source contains a hardcoded Alchemy NFT API URL in `projects/ui/src/pages/nft.tsx`. It was not seen in the initial live app bundle scan, but it should still be treated as exposed source key material if the route or code is shipped elsewhere.
+- Local Pinto UI source contains Alchemy URL construction in `src/utils/wagmi/chains.ts` and `src/pages/DevToolsInstall.tsx`, plus literal Alchemy URL examples/comments in the dev tools page. These should be removed or rotated if they point at live apps.
+
+## Security Posture
+
+- All `VITE_*`/client-side RPC keys should be treated as public identifiers, not secrets.
+- Frontend Alchemy keys are acceptable only if separately scoped for browser use, origin/domain restricted, quota limited, and monitored.
+- Backend/API/bot keys should use separate Alchemy apps with no browser origin allowlist dependency and should never be bundled into frontends.
+- Rotate any key that appears literally in source, comments, docs, old bundles, or test fixtures if it has real permissions or billable quota.
+
+## Port Order
+
+1. Beanstalk API:
+   - Port provider request batching and optional RPC request logging.
+   - Add historical RPC call caching for explicit `blockTag` reads.
+   - Add Multicall3 helpers where Beanstalk endpoints perform repeated per-token reads.
+   - Avoid Pinto's Base-only timestamp lookup shortcut unless Beanstalk chain behavior is handled explicitly.
+2. Beanstalk bots:
+   - Port HTTP RPC request counting.
+   - Add a shared event dispatcher for Well, Beanstalk, and Market monitors.
+   - De-duplicate contract/event filters and reuse receipts instead of fetching the same transaction receipts repeatedly.
+   - Keep Beanstalk-only monitors such as Barn Raise and Contracts Migrated separate until routing is verified.
+3. Beanstalk frontend:
+   - Port the app version refresh guard.
+   - Audit polling intervals and heavy reads against Pinto's lower-cost query defaults.
+   - Remove literal Alchemy URL/key examples from UI source where practical.
+
+## Verification Targets
+
+- API: targeted Jest tests around provider creation, cache behavior, and multicall-compatible service paths.
+- Bots: targeted unit/integration tests for event source construction, dispatcher routing, and receipt reuse.
+- Frontend: build/typecheck if the existing Beanstalk UI dependency state allows it; otherwise, static verification and minimal focused checks.
+

--- a/src/datasources/alchemy.js
+++ b/src/datasources/alchemy.js
@@ -1,33 +1,110 @@
 const { Alchemy } = require('alchemy-sdk');
 const EnvUtil = require('../utils/env');
+const { ethers } = require('ethers');
+const Log = require('../utils/logging');
+
+const RPC_BATCH_OPTIONS = {
+  batchMaxCount: Number(process.env.RPC_BATCH_MAX_COUNT ?? 10),
+  batchStallTime: Number(process.env.RPC_BATCH_STALL_TIME_MS ?? 10),
+  batchMaxSize: Number(process.env.RPC_BATCH_MAX_SIZE ?? 1024 * 1024)
+};
+const ETHERS_NETWORKS = {
+  eth: { name: 'mainnet', chainId: 1 },
+  arb: { name: 'arbitrum', chainId: 42161 }
+};
 
 class AlchemyUtil {
+  // Contains alchemy object
+  static _alchemies = {};
   // Contains a provider by chain
   static _providers = {};
   // Access to the underlying promise whos execution populates _providers.
   // Allows flexibility in awaiting when necessary (i.e. once at application startup)
   static _providerPromises = {};
+  static _rpcCounters = {};
 
   static {
     for (const chain of EnvUtil.getEnabledChains()) {
-      const settings = {
-        apiKey: EnvUtil.getAlchemyKey(),
-        network: `${chain}-mainnet` // Of type alchemy-sdk.Network
-      };
-      const alchemy = new Alchemy(settings);
-      this._providerPromises[chain] = alchemy.config.getProvider().then((p) => {
-        this._providers[chain] = p;
-      });
+      if (EnvUtil.getCustomRpcUrl(chain)) {
+        this._providers[chain] = this._makeProvider(chain, EnvUtil.getCustomRpcUrl(chain));
+      } else {
+        const settings = {
+          apiKey: EnvUtil.getAlchemyKey(),
+          network: `${chain}-mainnet` // Of type alchemy-sdk.Network
+        };
+        this._alchemies[chain] = new Alchemy(settings);
+        this._providers[chain] = this._makeProvider(
+          chain,
+          `https://${chain}-mainnet.g.alchemy.com/v2/${EnvUtil.getAlchemyKey()}`
+        );
+      }
     }
+  }
+
+  static alchemyForChain(chain) {
+    return AlchemyUtil._alchemies[chain];
   }
 
   static providerForChain(chain) {
     return AlchemyUtil._providers[chain];
   }
 
+  static rpcCounts(chain) {
+    return AlchemyUtil._rpcCounters[chain];
+  }
+
   // Returns immediately if already resolved (and _providers is populated)
   static async ready(chain) {
     await AlchemyUtil._providerPromises[chain];
+  }
+
+  static _makeProvider(chain, url) {
+    const provider = new ethers.JsonRpcProvider(url, ETHERS_NETWORKS[chain], RPC_BATCH_OPTIONS);
+    // Needed to get the alchemy-sdk Contract constructor to work with an ethers v6 provider.
+    provider._isProvider = true;
+    return AlchemyUtil._withRequestCounter(chain, provider);
+  }
+
+  static _withRequestCounter(chain, provider) {
+    if (process.env.LOG_RPC !== '1' || !provider._send) {
+      return provider;
+    }
+
+    const counter = {
+      total: 0,
+      methods: {}
+    };
+    AlchemyUtil._rpcCounters[chain] = counter;
+
+    const originalSend = provider._send.bind(provider);
+    provider._send = async (payload) => {
+      const requests = Array.isArray(payload) ? payload : [payload];
+      for (const request of requests) {
+        counter.total++;
+        counter.methods[request.method] = (counter.methods[request.method] ?? 0) + 1;
+      }
+      return await originalSend(payload);
+    };
+
+    let didLog = false;
+    const logCounts = () => {
+      if (didLog) {
+        return;
+      }
+      didLog = true;
+      Log.info(`RPC request counts for ${chain}`, JSON.stringify(counter));
+    };
+    process.once('beforeExit', logCounts);
+    process.once('exit', logCounts);
+    process.once('SIGINT', () => {
+      logCounts();
+      process.exit(0);
+    });
+    process.once('SIGTERM', () => {
+      logCounts();
+      process.exit(0);
+    });
+    return provider;
   }
 }
 

--- a/src/datasources/contracts/contracts.js
+++ b/src/datasources/contracts/contracts.js
@@ -1,5 +1,6 @@
 const { Contract: AlchemyContract } = require('alchemy-sdk');
 const { C } = require('../../constants/runtime-constants');
+const RpcCache = require('../rpc-cache');
 const SuperContract = require('./super-contract');
 const wellFunctionAbi = require('../../datasources/abi/basin/WellFunction.json');
 
@@ -20,10 +21,11 @@ class Contracts {
 
   static makeContract(address, abi, provider) {
     const underlyingContract = new AlchemyContract(address, abi, provider);
-    return new SuperContract(underlyingContract);
+    return RpcCache.wrapContract(new SuperContract(underlyingContract), address);
   }
 
   static _getDefaultContract(address, c = C()) {
+    address = address.toLowerCase();
     const network = c.CHAIN;
     const key = JSON.stringify({ address, network });
     if (!Contracts._contracts[key]) {

--- a/src/datasources/contracts/multicall.js
+++ b/src/datasources/contracts/multicall.js
@@ -1,0 +1,91 @@
+const { C } = require('../../constants/runtime-constants');
+const retryable = require('../../utils/async/retryable');
+const SuperContract = require('./super-contract');
+const Contracts = require('./contracts');
+
+const MULTICALL3_ADDRESS = '0xcA11bde05977b3631167028862bE2a173976CA11';
+const MULTICALL3_ABI = [
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: 'address', name: 'target', type: 'address' },
+          { internalType: 'bool', name: 'allowFailure', type: 'bool' },
+          { internalType: 'bytes', name: 'callData', type: 'bytes' }
+        ],
+        internalType: 'struct Multicall3.Call3[]',
+        name: 'calls',
+        type: 'tuple[]'
+      }
+    ],
+    name: 'aggregate3',
+    outputs: [
+      {
+        components: [
+          { internalType: 'bool', name: 'success', type: 'bool' },
+          { internalType: 'bytes', name: 'returnData', type: 'bytes' }
+        ],
+        internalType: 'struct Multicall3.Result[]',
+        name: 'returnData',
+        type: 'tuple[]'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  }
+];
+
+class Multicall {
+  static async aggregate(calls, { blockTag = 'latest', c = C() } = {}) {
+    if (calls.length === 0) {
+      return [];
+    }
+
+    const results = new Array(calls.length);
+    const callsByBlock = calls.reduce((acc, call, index) => {
+      const callBlock = call.blockTag ?? blockTag;
+      if (!acc.has(callBlock)) {
+        acc.set(callBlock, []);
+      }
+      acc.get(callBlock).push({ call, index });
+      return acc;
+    }, new Map());
+
+    await Promise.all(
+      [...callsByBlock.entries()].map(async ([callBlock, entries]) => {
+        const multicall = Contracts.makeContract(MULTICALL3_ADDRESS, MULTICALL3_ABI, c.RPC);
+        const aggregateCalls = entries.map(({ call }) => ({
+          target: call.contract.address,
+          allowFailure: call.allowFailure ?? false,
+          callData: call.contract.interface.encodeFunctionData(call.method, call.args ?? [])
+        }));
+
+        const aggregateResults = await retryable(() =>
+          multicall.aggregate3({ target: 'SuperContract', skipTransform: true }, aggregateCalls, {
+            blockTag: callBlock
+          })
+        );
+
+        for (let i = 0; i < entries.length; ++i) {
+          const { call, index } = entries[i];
+          const result = aggregateResults[i];
+          if (!result.success) {
+            if (call.allowFailure) {
+              results[index] = null;
+              continue;
+            }
+            throw new Error(`Multicall failed for ${call.contract.address}.${call.method}`);
+          }
+
+          const fragment = call.contract.interface.getFunction(call.method);
+          const decoded = call.contract.interface.decodeFunctionResult(fragment, result.returnData);
+          results[index] = SuperContract._transformAll(fragment.outputs.length === 1 ? decoded[0] : decoded);
+        }
+      })
+    );
+
+    return results;
+  }
+}
+
+module.exports = Multicall;

--- a/src/datasources/contracts/super-contract.js
+++ b/src/datasources/contracts/super-contract.js
@@ -17,13 +17,32 @@ class SuperContract {
         }
 
         return async (...args) => {
-          const rawResult = await retryable(() => contract[property](...args));
+          const { superOptions, contractArgs } = SuperContract._identifySuperArgs(args);
+
+          const retryableOptions = {};
+          if (superOptions?.skipRetry) {
+            retryableOptions.earlyTerminate = superOptions.skipRetry;
+          }
+          const rawResult = await retryable(() => contract[property](...contractArgs), retryableOptions);
+
+          if (superOptions?.skipTransform) {
+            return rawResult;
+          }
           return SuperContract._transformAll(rawResult);
         };
       }
     };
 
     return new Proxy(this, proxyHandler);
+  }
+
+  static _identifySuperArgs(args) {
+    const superArgsIndex = args.findIndex((a) => a?.target === 'SuperContract');
+    if (superArgsIndex !== -1) {
+      const superOptions = args.splice(superArgsIndex, 1)[0];
+      return { superOptions, contractArgs: args };
+    }
+    return { contractArgs: args };
   }
 
   // Transforms everything in this result to be a BigInt.

--- a/src/datasources/rpc-cache.js
+++ b/src/datasources/rpc-cache.js
@@ -1,0 +1,100 @@
+const crypto = require('crypto');
+
+const BIGINT_PREFIX = 'bigint:';
+
+class RpcCache {
+  static _redisClient;
+
+  static wrapContract(contract, address) {
+    return new Proxy(contract, {
+      get(target, property, receiver) {
+        if (typeof property !== 'string') {
+          return target[property];
+        }
+        if (['interface', 'provider', 'filters', 'address', 'then'].includes(property)) {
+          return target[property];
+        }
+
+        return async (...args) => {
+          const cache = RpcCache._cacheRequest(address, property, args);
+          if (!cache) {
+            return await target[property](...args);
+          }
+
+          const cachedValue = await RpcCache._get(cache.key);
+          if (cachedValue !== null) {
+            return RpcCache._deserialize(cachedValue);
+          }
+
+          const result = await target[property](...args);
+          await RpcCache._set(cache.key, RpcCache._serialize(result));
+          return result;
+        };
+      }
+    });
+  }
+
+  static _cacheRequest(address, method, args) {
+    const superArgsIndex = args.findIndex((a) => a?.target === 'SuperContract');
+    const superOptions = superArgsIndex === -1 ? null : args[superArgsIndex];
+    if (superOptions?.skipTransform) {
+      return null;
+    }
+
+    const contractArgs = args.filter((_, idx) => idx !== superArgsIndex);
+    const callOptions = contractArgs.find((a) => a && typeof a === 'object' && a.blockTag !== undefined);
+    const blockTag = callOptions?.blockTag;
+    if (!RpcCache._isHistoricalBlockTag(blockTag)) {
+      return null;
+    }
+
+    return {
+      key: `rpc:${address.toLowerCase()}:${method}:${RpcCache._hash({ args: contractArgs, blockTag })}`
+    };
+  }
+
+  static _isHistoricalBlockTag(blockTag) {
+    if (typeof blockTag === 'number' || typeof blockTag === 'bigint') {
+      return true;
+    }
+    return typeof blockTag === 'string' && /^0x[0-9a-f]+$/i.test(blockTag);
+  }
+
+  static async _get(key) {
+    try {
+      return await RpcCache._client().get(key);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  static async _set(key, value) {
+    try {
+      await RpcCache._client().set(key, value);
+    } catch (e) {}
+  }
+
+  static _client() {
+    RpcCache._redisClient ??= require('./redis-client');
+    return RpcCache._redisClient;
+  }
+
+  static _hash(value) {
+    return crypto.createHash('sha256').update(RpcCache._serialize(value)).digest('hex');
+  }
+
+  static _serialize(value) {
+    return JSON.stringify(value, (_, v) => (typeof v === 'bigint' ? `${BIGINT_PREFIX}${v.toString()}` : v));
+  }
+
+  static _deserialize(value) {
+    return JSON.parse(value, (_, v) => {
+      if (typeof v === 'string' && v.startsWith(BIGINT_PREFIX)) {
+        return BigInt(v.slice(BIGINT_PREFIX.length));
+      }
+      return v;
+    });
+  }
+}
+
+module.exports = RpcCache;

--- a/src/service/silo-service.js
+++ b/src/service/silo-service.js
@@ -1,12 +1,12 @@
 const { C } = require('../constants/runtime-constants');
 const Contracts = require('../datasources/contracts/contracts');
+const Multicall = require('../datasources/contracts/multicall');
 const TokenRepository = require('../repository/postgres/queries/token-repository');
 const BeanstalkSubgraphRepository = require('../repository/subgraph/beanstalk-subgraph');
 const ArraysUtil = require('../utils/arrays');
 const BlockUtil = require('../utils/block');
 const Concurrent = require('../utils/async/concurrent');
 const { createNumberSpread } = require('../utils/number');
-const PromiseUtil = require('../utils/async/promise');
 const AsyncContext = require('../utils/async/context');
 
 class SiloService {
@@ -118,22 +118,26 @@ class SiloService {
     const tokenModels = await TokenRepository.findWhitelistedTokens(chain);
     const addresses = tokenModels.map((t) => t.address);
 
-    const results = await Promise.all(
-      addresses.map(async (t) => {
-        const [tokenSetting, stemTip, bdv] = await Promise.all([
-          beanstalk.tokenSettings(t, { blockTag: block }),
-          beanstalk.stemTipForToken(t, { blockTag: block }),
-          PromiseUtil.defaultOnReject(1n)(beanstalk.bdv(t, BigInt(10 ** C().DECIMALS[t]), { blockTag: block }))
-        ]);
-        return { tokenSetting, stemTip, bdv };
-      })
+    const multicallResults = await Multicall.aggregate(
+      addresses.flatMap((t) => [
+        { contract: beanstalk, method: 'tokenSettings', args: [t], blockTag: block },
+        { contract: beanstalk, method: 'stemTipForToken', args: [t], blockTag: block },
+        {
+          contract: beanstalk,
+          method: 'bdv',
+          args: [t, BigInt(10 ** C().DECIMALS[t])],
+          blockTag: block,
+          allowFailure: true
+        }
+      ])
     );
 
     return addresses.reduce((acc, next, idx) => {
+      const resultIndex = idx * 3;
       acc[next] = {
-        ...results[idx].tokenSetting,
-        stemTip: results[idx].stemTip,
-        bdv: results[idx].bdv
+        ...multicallResults[resultIndex],
+        stemTip: multicallResults[resultIndex + 1],
+        bdv: multicallResults[resultIndex + 2] ?? 1n
       };
       return acc;
     }, {});
@@ -143,14 +147,23 @@ class SiloService {
   static async getMowStems(accountTokenPairs, blockNumber) {
     const results = {};
     const beanstalk = Contracts.getBeanstalk();
-    const TAG = Concurrent.tag('getMowStems');
-    for (let i = 0; i < accountTokenPairs.length; ++i) {
-      const { account, token } = accountTokenPairs[i];
-      await Concurrent.run(TAG, 50, async () => {
-        results[`${account}|${token}`] = await beanstalk.getLastMowedStem(account, token, { blockTag: blockNumber });
-      });
+    const pairChunks = ArraysUtil.toChunks(accountTokenPairs, 500);
+
+    for (const pairChunk of pairChunks) {
+      const chunkResults = await Multicall.aggregate(
+        pairChunk.map(({ account, token }) => ({
+          contract: beanstalk,
+          method: 'getLastMowedStem',
+          args: [account, token],
+          blockTag: blockNumber
+        }))
+      );
+
+      for (let i = 0; i < pairChunk.length; ++i) {
+        const { account, token } = pairChunk[i];
+        results[`${account}|${token}`] = chunkResults[i];
+      }
     }
-    await Concurrent.allResolved(TAG);
 
     return results;
   }
@@ -187,21 +200,35 @@ class SiloService {
 
     const updatedTokens = [];
     await AsyncContext.sequelizeTransaction(async () => {
-      for (const tokenModel of tokenModels) {
+      const multicallResults = await Multicall.aggregate(
+        tokenModels.flatMap((tokenModel) => {
+          const token = tokenModel.address;
+          return [
+            { contract: Contracts.get(token), method: 'totalSupply', allowFailure: true },
+            {
+              contract: beanstalk,
+              method: 'bdv',
+              args: [token, BigInt(10 ** tokenModel.decimals)],
+              allowFailure: true
+            },
+            { contract: beanstalk, method: 'tokenSettings', args: [token], allowFailure: true },
+            { contract: beanstalk, method: 'stemTipForToken', args: [token], allowFailure: true },
+            { contract: beanstalk, method: 'getTotalDeposited', args: [token], allowFailure: true },
+            { contract: beanstalk, method: 'getTotalDepositedBdv', args: [token], allowFailure: true }
+          ];
+        })
+      );
+
+      for (let i = 0; i < tokenModels.length; ++i) {
+        const tokenModel = tokenModels[i];
         const token = tokenModel.address;
-        const [supply, bdv, stalkEarnedPerSeason, stemTip, totalDeposited, totalDepositedBdv] = await Promise.all(
-          [
-            Contracts.get(token).totalSupply(),
-            PromiseUtil.defaultOnReject(1n)(beanstalk.bdv(token, BigInt(10 ** tokenModel.decimals))),
-            (async () => {
-              const tokenSettings = await beanstalk.tokenSettings(token);
-              return tokenSettings.stalkEarnedPerSeason;
-            })(),
-            beanstalk.stemTipForToken(token),
-            beanstalk.getTotalDeposited(token),
-            beanstalk.getTotalDepositedBdv(token)
-          ].map(PromiseUtil.defaultOnReject(null))
-        );
+        const resultIndex = i * 6;
+        const supply = multicallResults[resultIndex] ?? null;
+        const bdv = multicallResults[resultIndex + 1] ?? 1n;
+        const stalkEarnedPerSeason = multicallResults[resultIndex + 2]?.stalkEarnedPerSeason ?? null;
+        const stemTip = multicallResults[resultIndex + 3] ?? null;
+        const totalDeposited = multicallResults[resultIndex + 4] ?? null;
+        const totalDepositedBdv = multicallResults[resultIndex + 5] ?? null;
 
         updatedTokens.push(
           ...(await TokenRepository.updateToken(token, chain, {

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -1,6 +1,7 @@
 require('dotenv').config();
 const ChainUtil = require('./chain');
 
+const CUSTOM_RPC = process.env.CUSTOM_RPC;
 const ALCHEMY_API_KEY = process.env.ALCHEMY_API_KEY;
 const GRAPH_API_KEY = process.env.GRAPH_API_KEY;
 
@@ -50,6 +51,10 @@ class EnvUtil {
 
   static defaultChain() {
     return ENABLED_CHAINS[0];
+  }
+
+  static getCustomRpcUrl(chain) {
+    return CUSTOM_RPC?.split(',')[EnvUtil.getEnabledChains().indexOf(chain)];
   }
 
   static getAlchemyKey() {

--- a/test/datasources/multicall.test.js
+++ b/test/datasources/multicall.test.js
@@ -1,0 +1,74 @@
+const { ethers } = require('ethers');
+
+jest.mock('../../src/datasources/contracts/contracts', () => ({
+  makeContract: jest.fn()
+}));
+
+const Contracts = require('../../src/datasources/contracts/contracts');
+const Multicall = require('../../src/datasources/contracts/multicall');
+
+describe('Multicall', () => {
+  beforeEach(() => {
+    Contracts.makeContract.mockReset();
+  });
+
+  test('decodes aggregate3 responses in request order', async () => {
+    const tokenInterface = new ethers.Interface(['function balanceOf(address account) view returns (uint256)']);
+    const token = {
+      address: '0x0000000000000000000000000000000000000001',
+      interface: tokenInterface
+    };
+    const multicall = {
+      aggregate3: jest.fn().mockResolvedValue([
+        {
+          success: true,
+          returnData: tokenInterface.encodeFunctionResult('balanceOf', [123n])
+        }
+      ])
+    };
+    Contracts.makeContract.mockReturnValue(multicall);
+
+    const results = await Multicall.aggregate([
+      {
+        contract: token,
+        method: 'balanceOf',
+        args: ['0x0000000000000000000000000000000000000002'],
+        blockTag: 100
+      }
+    ]);
+
+    expect(multicall.aggregate3).toHaveBeenCalledWith(
+      { target: 'SuperContract', skipTransform: true },
+      [
+        {
+          target: token.address,
+          allowFailure: false,
+          callData: tokenInterface.encodeFunctionData('balanceOf', ['0x0000000000000000000000000000000000000002'])
+        }
+      ],
+      { blockTag: 100 }
+    );
+    expect(results).toEqual([123n]);
+  });
+
+  test('returns null for allowed failed calls', async () => {
+    const tokenInterface = new ethers.Interface(['function symbol() view returns (string)']);
+    const multicall = {
+      aggregate3: jest.fn().mockResolvedValue([{ success: false, returnData: '0x' }])
+    };
+    Contracts.makeContract.mockReturnValue(multicall);
+
+    const results = await Multicall.aggregate([
+      {
+        contract: {
+          address: '0x0000000000000000000000000000000000000001',
+          interface: tokenInterface
+        },
+        method: 'symbol',
+        allowFailure: true
+      }
+    ]);
+
+    expect(results).toEqual([null]);
+  });
+});

--- a/test/datasources/rpc-cache.test.js
+++ b/test/datasources/rpc-cache.test.js
@@ -1,0 +1,53 @@
+const store = new Map();
+const mockRedisClient = {
+  get: jest.fn((key) => Promise.resolve(store.get(key) ?? null)),
+  set: jest.fn((key, value) => {
+    store.set(key, value);
+    return Promise.resolve();
+  })
+};
+
+jest.mock('../../src/datasources/redis-client', () => mockRedisClient);
+
+const RpcCache = require('../../src/datasources/rpc-cache');
+
+describe('RpcCache', () => {
+  beforeEach(() => {
+    store.clear();
+    jest.clearAllMocks();
+  });
+
+  test('caches historical contract reads by method, args, and blockTag', async () => {
+    const contract = {
+      balanceOf: jest.fn().mockResolvedValue(123n)
+    };
+    const cached = RpcCache.wrapContract(contract, '0x0000000000000000000000000000000000000001');
+
+    await expect(cached.balanceOf('0x0000000000000000000000000000000000000002', { blockTag: 100 })).resolves.toEqual(
+      123n
+    );
+    await expect(cached.balanceOf('0x0000000000000000000000000000000000000002', { blockTag: 100 })).resolves.toEqual(
+      123n
+    );
+
+    expect(contract.balanceOf).toHaveBeenCalledTimes(1);
+    expect(mockRedisClient.get).toHaveBeenCalledTimes(2);
+    expect(mockRedisClient.set).toHaveBeenCalledTimes(1);
+  });
+
+  test('skips cache for moving block tags', async () => {
+    const contract = {
+      balanceOf: jest.fn().mockResolvedValue(123n)
+    };
+    const cached = RpcCache.wrapContract(contract, '0x0000000000000000000000000000000000000001');
+
+    await cached.balanceOf('0x0000000000000000000000000000000000000002', { blockTag: 'latest' });
+    await cached.balanceOf('0x0000000000000000000000000000000000000002', { blockTag: 'safe' });
+    await cached.balanceOf('0x0000000000000000000000000000000000000002', { blockTag: 'pending' });
+    await cached.balanceOf('0x0000000000000000000000000000000000000002');
+
+    expect(contract.balanceOf).toHaveBeenCalledTimes(4);
+    expect(mockRedisClient.get).not.toHaveBeenCalled();
+    expect(mockRedisClient.set).not.toHaveBeenCalled();
+  });
+});

--- a/test/setup/jest.setup.js
+++ b/test/setup/jest.setup.js
@@ -3,12 +3,14 @@ jest.mock('../../src/utils/env', () => {
   return {
     isChainEnabled: jest.fn(),
     defaultChain: jest.fn().mockReturnValue('eth'),
+    getCustomRpcUrl: jest.fn(),
     getAlchemyKey: jest.fn(),
     getEnabledChains: jest.fn(),
     getEnabledCronJobs: jest.fn(),
     getDeploymentEnv: jest.fn(),
     getDiscordWebhooks: jest.fn(),
     getDiscordPrefix: jest.fn(),
+    getRedisUrl: jest.fn().mockReturnValue('redis://localhost:6379'),
     getSG: jest.fn().mockImplementation(() => ({
       BEANSTALK: 'a',
       BEAN: 'b',


### PR DESCRIPTION
## Summary
- add an RPC cost optimization port plan
- enable ethers JSON-RPC batching, optional custom RPC URLs, and RPC request counters
- add Redis-backed historical block-tag RPC caching
- collapse heavy Silo token info paths through Multicall3

## Validation
- npm test -- --runInBand test/datasources/rpc-cache.test.js test/datasources/multicall.test.js test/service/silo-service.test.js
- npm test -- --runInBand

## Notes
- no production deploy is triggered until this PR is merged into main